### PR TITLE
Fix blacklist

### DIFF
--- a/src/main/java/net/darkhax/eplus/api/Blacklist.java
+++ b/src/main/java/net/darkhax/eplus/api/Blacklist.java
@@ -30,7 +30,7 @@ public final class Blacklist {
 
         for (final ItemStack blacklisted : BLACKLIST_ITEMS) {
 
-            if (StackUtils.areStacksSimilarWithPartialNBT(blacklisted, stack)) {
+            if (StackUtils.areStacksSimilar(blacklisted, stack)) {
 
                 return true;
             }

--- a/src/main/java/net/darkhax/eplus/gui/GuiEnchantmentLabel.java
+++ b/src/main/java/net/darkhax/eplus/gui/GuiEnchantmentLabel.java
@@ -109,7 +109,6 @@ public class GuiEnchantmentLabel extends Gui {
      * the enchantment being represented.
      *
      * @param xPos The xPos of the slider.
-     * @param baseX The previous slider position.
      */
     public void updateSlider (int xPos) {
 


### PR DESCRIPTION
This should fix #161 by not checking for similar NBT tags. This allows modded installs to function properly (since you can't specify NBT in the configuration file)