### PR TITLE
Allow treasure enchantments to be added to enchantment list when appr…

### DIFF
--- a/src/main/java/net/darkhax/eplus/EnchLogic.java
+++ b/src/main/java/net/darkhax/eplus/EnchLogic.java
@@ -64,8 +64,9 @@ public final class EnchLogic {
                     continue;
                 }
 
-                if (!enchantment.isTreasureEnchantment() || isCurse(world, enchantment) || isTreasuresAvailable(enchantment, world, pos, pos.down())) {
-
+                if (isCurse(world, enchantment) || isTreasuresAvailable(enchantment, world, pos, pos.down())) {
+                    enchList.add(enchantment);
+                } else if (!enchantment.isTreasureEnchantment() && !enchantment.isCurse())
                     enchList.add(enchantment);
                 }
             }
@@ -94,7 +95,6 @@ public final class EnchLogic {
                 final Block block = world.getBlockState(currentPos).getBlock();
                 
                 if (!block.isBeaconBase(world, currentPos, pos)) {
-                    
                     return false;
                 }
             }


### PR DESCRIPTION
…opriate.

This change will allow for treasure enchantments to be in the enchantment list if it meets the credentials of isTreasuresAvailable (3x3 centered beacon blocks on advanced enchantment table).

If this is no longer maintained I will create a fork mod